### PR TITLE
docker: build static binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,17 @@
-# Builder
-FROM ubuntu:22.04 as builder
-ENV DEBIAN_FRONTEND=noninteractive
+FROM alpine:3 AS builder
+ENV LDFLAGS=-static
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends --quiet --yes \
-        build-essential \
-        cmake \
-        ninja-build \
-        python3-pip && \
-    rm --force --recursive /var/lib/apt/lists/*
-
-# hadolint ignore=DL3059
-RUN python3 -m pip install --no-cache-dir build conan>=1.35
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash binutils cmake git gcc g++ linux-headers make ninja py3-pip && \
+    python3 -m pip install --no-cache-dir build conan>=1.35
 
 WORKDIR /tmp
 COPY . .
 
 RUN cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_PYTHON=OFF -DWITH_TESTS=OFF && \
-    cmake --build build --target caracal-bin
+    cmake --build build --target caracal-bin && \
+    strip build/caracal
 
-# Main
-FROM ubuntu:22.04
+FROM scratch
 COPY --from=builder /tmp/build/caracal /usr/bin/caracal
 ENTRYPOINT ["caracal"]

--- a/extern/liblpm/src/lpm.h
+++ b/extern/liblpm/src/lpm.h
@@ -8,7 +8,9 @@
 #ifndef _LPM_H_
 #define _LPM_H_
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct lpm lpm_t;
 typedef void (*lpm_dtor_t)(void *, const void *, size_t, void *);
@@ -23,6 +25,8 @@ void *		lpm_lookup(lpm_t *, const void *, size_t);
 void *		lpm_lookup_prefix(lpm_t *, const void *, size_t, unsigned);
 int		lpm_strtobin(const char *, void *, size_t *, unsigned *);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build-frontend = "build"
-# To build with musl libc we need https://github.com/rmind/liblpm/pull/18
-skip = ["*-musllinux_*"]
 # `2021-08-01-bce1ff9` is the latest version that uses GCC 9.
 # The current version with GCC 10 has a bug where it references `pthread_cond_clockwait`
 # in the built binary even though it doesn't exists in the bundled libpthread version.


### PR DESCRIPTION
This brings the uncompressed image size from 70MB to 2MB.