### PR TITLE
fix building issue with conan >2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.1
+current_version = 0.14.2
 commit = True
 tag = True
 message = release(project): {current_version} → {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.2
+current_version = 0.14.3
 commit = True
 tag = True
 message = release(project): {current_version} → {new_version}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install --yes build-essential cmake gcovr ninja-build python3-pip
-          pip3 install conan<2.0
+          pip3 install "conan<2.0"
       - name: Configure project
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -fsanitize=address -fsanitize=undefined" -DWITH_CONAN=ON -DWITH_TESTS=ON
       - name: Build tests
@@ -56,7 +56,7 @@ jobs:
           path: ~/.conan/data
           key: ${{ runner.os }}-x86_64
       - name: Install dependencies
-        run: brew install cmake conan<2.0 gcovr ninja
+        run: brew install cmake "conan<2.0" gcovr ninja
       - name: Configure project (try 1/2)
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -fsanitize=address -fsanitize=undefined" -DWITH_CONAN=ON -DWITH_TESTS=ON
         continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v20
       - uses: cachix/cachix-action@v12
         with:
           name: ${{ secrets.CACHIX_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,9 @@ jobs:
           path: ~/.conan/data
           key: ${{ runner.os }}-x86_64
       - name: Install dependencies
-        run: brew install cmake "conan<2.0" gcovr ninja
+        run: brew install cmake gcovr ninja
+      - name: Install Conan
+        run: pip3 install "conan<2.0"
       - name: Configure project (try 1/2)
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -fsanitize=address -fsanitize=undefined" -DWITH_CONAN=ON -DWITH_TESTS=ON
         continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install --yes build-essential cmake gcovr ninja-build python3-pip
-          pip3 install conan
+          pip3 install conan<2.0
       - name: Configure project
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -fsanitize=address -fsanitize=undefined" -DWITH_CONAN=ON -DWITH_TESTS=ON
       - name: Build tests
@@ -56,7 +56,7 @@ jobs:
           path: ~/.conan/data
           key: ${{ runner.os }}-x86_64
       - name: Install dependencies
-        run: brew install cmake conan gcovr ninja
+        run: brew install cmake conan<2.0 gcovr ninja
       - name: Configure project (try 1/2)
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -fsanitize=address -fsanitize=undefined" -DWITH_CONAN=ON -DWITH_TESTS=ON
         continue-on-error: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(caracal VERSION 0.14.1)
+project(caracal VERSION 0.14.2)
 
 # We have Find* modules in two places:
 # - The build directory, for the libraries fetched by Conan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(caracal VERSION 0.14.2)
+project(caracal VERSION 0.14.3)
 
 # We have Find* modules in two places:
 # - The build directory, for the libraries fetched by Conan

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --quiet --yes \
-        build-essential \
-        cmake \
-        ninja-build \
-        python3-pip && \
+    build-essential \
+    cmake \
+    ninja-build \
+    python3-pip && \
     rm --force --recursive /var/lib/apt/lists/*
 
 # hadolint ignore=DL3059
-RUN python3 -m pip install --no-cache-dir build conan>=1.35
+RUN python3 -m pip install --no-cache-dir build "conan>=1.35,<2.0"
 
 WORKDIR /tmp
 COPY . .

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         packages = {
           caracal = pkgs.stdenv.mkDerivation {
             pname = "caracal";
-            version = "0.14.2";
+            version = "0.14.3";
             src = self;
             nativeBuildInputs = [
               pkgs.cmake

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         packages = {
           caracal = pkgs.stdenv.mkDerivation {
             pname = "caracal";
-            version = "0.14.1";
+            version = "0.14.2";
             src = self;
             nativeBuildInputs = [
               pkgs.cmake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake", "conan", "ninja", "scikit-build", "pybind11"]
+requires = ["setuptools", "wheel", "cmake", "conan <2.0", "ninja", "scikit-build", "pybind11"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake", "conan <2.0", "ninja", "scikit-build", "pybind11"]
+requires = ["setuptools", "wheel", "cmake", "conan<2.0", "ninja", "scikit-build", "pybind11"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from skbuild import setup
 
 setup(
     name="pycaracal",
-    version="0.14.2",
+    version="0.14.3",
     author="Maxime Mouchet",
     author_email="max@maxmouchet.com",
     url="https://github.com/dioptra-io/caracal",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from skbuild import setup
 
 setup(
     name="pycaracal",
-    version="0.14.1",
+    version="0.14.2",
     author="Maxime Mouchet",
     author_email="max@maxmouchet.com",
     url="https://github.com/dioptra-io/caracal",


### PR DESCRIPTION
Since Feb. 2023, a new major version of Conan is out (see https://blog.conan.io/2023/02/22/Conan-2.0.html).
It seems to break the building of Caracal due to changes in configuration file handling AFAIK. 

Example of failing here : 
```
#24 16.72   ERROR: Error while parsing [options] in conanfile.txt
#24 16.72   Options should be specified as 'pkg/*:option=value'
#24 16.75   CMake Error at cmake/conan.cmake:638 (message):
#24 16.75     Conan install failed='1'
#24 16.75   Call Stack (most recent call first):
#24 16.75     CMakeLists.txt:42 (conan_cmake_install)
#24 16.75 
```

This PR enforces the building with Conan <2.0. 
LMK if something else needs to be done. 
