### PR TITLE
pypi: disable macOS builds

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -60,44 +60,44 @@ jobs:
           sdist: false
           wheel: false
 
-  macos:
-    runs-on: macos-10.15
-    strategy:
-      matrix:
-        arch: ["x86_64", "arm64"]
-        build:
-          ["cp38-macosx*", "cp39-macosx*", "cp310-macosx*", "cp311-macosx*"]
-        include:
-          - arch: "x86_64"
-            conan_arch: "x86_64"
-          - arch: "arm64"
-            conan_arch: "armv8"
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.conan/data
-          key: ${{ runner.os }}-${{ matrix.arch }}-${{ matrix.build }}
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.9.0
-        env:
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: ${{ matrix.build }}
-          CONAN_ARCH: ${{ matrix.conan_arch }}
-          CMAKE_OSX_ARCHITECTURES: ${{ matrix.arch }}
-          MACOSX_DEPLOYMENT_TARGET: 10.15
-        with:
-          output-dir: dist
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          path: dist/*.whl
-      - uses: dioptra-io/publish-python-action@v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-          upload: ${{ startsWith(github.ref, 'refs/tags/v') }}
-          sdist: false
-          wheel: false
+#   macos:
+#     runs-on: macos-10.15
+#     strategy:
+#       matrix:
+#         arch: ["x86_64", "arm64"]
+#         build:
+#           ["cp38-macosx*", "cp39-macosx*", "cp310-macosx*", "cp311-macosx*"]
+#         include:
+#           - arch: "x86_64"
+#             conan_arch: "x86_64"
+#           - arch: "arm64"
+#             conan_arch: "armv8"
+#     steps:
+#       - uses: actions/checkout@v3
+#       - uses: actions/cache@v3
+#         with:
+#           path: ~/.conan/data
+#           key: ${{ runner.os }}-${{ matrix.arch }}-${{ matrix.build }}
+#       - uses: actions/setup-python@v4
+#         with:
+#           python-version: "3.x"
+#       - name: Build wheels
+#         uses: pypa/cibuildwheel@v2.9.0
+#         env:
+#           CIBW_ARCHS: ${{ matrix.arch }}
+#           CIBW_BUILD: ${{ matrix.build }}
+#           CONAN_ARCH: ${{ matrix.conan_arch }}
+#           CMAKE_OSX_ARCHITECTURES: ${{ matrix.arch }}
+#           MACOSX_DEPLOYMENT_TARGET: 10.15
+#         with:
+#           output-dir: dist
+#       - name: Upload artifacts
+#         uses: actions/upload-artifact@v3
+#         with:
+#           path: dist/*.whl
+#       - uses: dioptra-io/publish-python-action@v1
+#         with:
+#           password: ${{ secrets.PYPI_TOKEN }}
+#           upload: ${{ startsWith(github.ref, 'refs/tags/v') }}
+#           sdist: false
+#           wheel: false


### PR DESCRIPTION
The `macos-10.15` runners is not available anymore on GitHub actions and libtins fails to build on more recent versions due to a dependency on libpcap which itself depends on flex which doesn't build:

```
  flex/2.6.4: Calling:
   > "/Users/runner/.conan/data/flex/2.6.4/_/_/build/3bfcab01fd7aed1a364eef7904a0d17bab222ae0/configure" '--disable-shared' '--enable-static' '--prefix=/' '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' '--disable-nls' '--disable-bootstrap' 'HELP2MAN=/bin/true' 'M4=m4' 'ac_cv_func_malloc_0_nonnull=yes' 'ac_cv_func_realloc_0_nonnull=yes' 'ac_cv_func_reallocarray=no' 
  checking build system type... x86_64-apple-darwin21.6.0
  checking host system type... x86_64-apple-darwin21.6.0
  checking how to print strings... printf
  checking for gcc... /Applications/Xcode_14.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
  checking whether the C compiler works... no
  configure: error: in `/Users/runner/.conan/data/flex/2.6.4/_/_/build/3bfcab01fd7aed1a364eef7904a0d17bab222ae0':
  configure: error: C compiler cannot create executables
  See `config.log' for more details
  flex/2.6.4: 
  flex/2.6.4: ERROR: Package '3bfcab01fd7aed1a364eef7904a0d17bab222ae0' build failed
  flex/2.6.4: WARN: Build folder /Users/runner/.conan/data/flex/2.6.4/_/_/build/3bfcab01fd7aed1a364eef7904a0d17bab222ae0
```