### PR TITLE
sniffer: fix mangled newlines on stdout

### DIFF
--- a/include/caracal/sniffer.hpp
+++ b/include/caracal/sniffer.hpp
@@ -33,7 +33,6 @@ class Sniffer {
 
  private:
   Tins::Sniffer sniffer_;
-  std::unique_ptr<std::ostream> output_csv_;
   std::optional<Tins::PacketWriter> output_pcap_;
   std::optional<std::string> meta_round_;
   std::thread thread_;

--- a/src/sniffer.cpp
+++ b/src/sniffer.cpp
@@ -58,7 +58,6 @@ Sniffer::Sniffer(const std::string &interface_name,
   // they are captured by pcap.
   config.set_timeout(100);
   sniffer_ = Tins::Sniffer(interface_name, config);
-  output_csv_ = std::make_unique<std::ostream>(std::cout.rdbuf());
 }
 
 Sniffer::~Sniffer() {
@@ -68,7 +67,7 @@ Sniffer::~Sniffer() {
 }
 
 void Sniffer::start() noexcept {
-  *output_csv_ << Reply::csv_header() << "\n";
+  std::cout << (Reply::csv_header() + "\n");
   auto handler = [this](Tins::Packet &packet) {
     auto reply = Parser::parse(packet);
 
@@ -78,7 +77,7 @@ void Sniffer::start() noexcept {
       if (reply->is_time_exceeded()) {
         statistics_.icmp_messages_path.insert(reply->reply_src_addr);
       }
-      *output_csv_ << reply->to_csv(meta_round_.value_or("1")) << "\n";
+      std::cout << (reply->to_csv(meta_round_.value_or("1")) + "\n");
     } else {
       auto data = packet.pdu()->serialize();
       spdlog::trace("invalid_packet_hex={:02x}", fmt::join(data, ""));


### PR DESCRIPTION
Fixes an issue where caracal is sometimes missing a newline, or outputting a newline twice.