### PR TITLE
sniffer: fix mangled lines on stdout output

### DIFF
--- a/apps/caracal.cpp
+++ b/apps/caracal.cpp
@@ -131,7 +131,6 @@ int main(int argc, char** argv) {
     spdlog::set_default_logger(spdlog::stderr_color_st(""));
 
     spdlog::info("Reading from stdin, press CTRL+D to stop...");
-    std::ios::sync_with_stdio(false);
     caracal::Prober::probe(config, std::cin);
   } catch (const std::exception& e) {
     auto type = caracal::Utilities::demangle(typeid(e).name());


### PR DESCRIPTION
Newlines were fixed in #61 but we're still getting bad lines:
```
1704573826,1,::ffff:132.227.123.8,::ffff:37.61.226.8,24000,0,8,1,::ffff:62.40.98.238,1,11,0,241,172,"[(14716,0,0,11704573826,1,::ffff:132.227.123.8,::ffff:37.23.143.233,24000,0,8,1,::ffff:62.40.98.238,1,11,0,248,168,"[(62839,0,1,1)]",92,1
```

`std::ios::sync_with_stdio(false);` seems to be the culprit. From [`sync_with_stdio`](https://en.cppreference.com/w/cpp/io/ios_base/sync_with_stdio):
> In addition, synchronized C++ streams are guaranteed to be thread-safe (individual characters output from multiple threads may interleave, but no data races occur).
