### PR TITLE
fix: output capture_timestamp in microseconds instead of seconds

### DIFF
--- a/src/reply.cpp
+++ b/src/reply.cpp
@@ -23,7 +23,7 @@ std::string Reply::to_csv(const std::string& round) const {
                  std::back_inserter(mpls_labels_csv), mpls_label_to_csv);
   return fmt::format(
       "{},{},{},{},{},{},{},{},{},{},{},{},{},{},\"[{}]\",{},{}",
-      capture_timestamp / 1'000'000, probe_protocol, reply_dst_addr,
+      capture_timestamp, probe_protocol, reply_dst_addr,
       probe_dst_addr, probe_src_port, probe_dst_port, probe_ttl, quoted_ttl,
       reply_src_addr, reply_protocol, reply_icmp_type, reply_icmp_code,
       reply_ttl, reply_size, fmt::join(mpls_labels_csv, ","), rtt, round);


### PR DESCRIPTION
Remove the division by 1'000'000 in Reply::to_csv so that capture_timestamp is written as raw microseconds to the CSV output, preserving sub-second precision for RTT computation and logging.